### PR TITLE
Update 02-AEM-Magento.md

### DIFF
--- a/integrations/02-AEM-Magento.md
+++ b/integrations/02-AEM-Magento.md
@@ -63,7 +63,7 @@ From a catalog management point of view, Magento is responsible for all commerce
 
 ### Checkout
 
-This integration uses client-side Cart component that renders the shopping cart and the checkout form to demonstrate a full experience integration pattern where you can deliver commerce experiences with Magento running in a completely headless way and AEM owning the glass. This component requires the AEM Dispatcher to be setup with GraphQL routing to enable the AEM page to access Magento's GraphQL endpoint. Additionally, it is mandatory to use abstracted payment methods. This puts the browser client in direct communication with the payment gateway provider so that neither Adobe or Magento clouds hold or pass PCI sensitive data. 
+This integration uses client-side Cart component that renders the shopping cart and the checkout form to demonstrate a full experience integration pattern where you can deliver commerce experiences with Magento running in a completely headless way and AEM owning the glass. This component requires the AEM Dispatcher to be setup with GraphQL routing to enable the AEM page to access Magento's GraphQL endpoint. 
 
 ### Account Management
 


### PR DESCRIPTION
The latest CIF implementation doesn't require using only the abstracted payment methods. Braintree payment method allows to show iframe and fill credit card data on the AEM page.